### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -48,7 +48,11 @@ export const stripMobilePrefix = (url: string) => {
 }
 
 export const isFirebaseURL = (url: string) => {
-  return url.includes('https://soundcloud.app.goo.gl')
+  try {
+    return new URL(url).hostname === 'soundcloud.app.goo.gl'
+  } catch {
+    return false
+  }
 }
 
 export const convertFirebaseURL = async (url: string, axiosInstance: AxiosInstance) => {


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/5](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/5)

To fix the problem, we should parse the input URL using the standard `URL` class and check that the hostname matches exactly `soundcloud.app.goo.gl`. This ensures that only URLs with the correct host are considered Firebase URLs, and prevents bypasses using substring tricks. The change should be made in the `isFirebaseURL` function (lines 50-52). We should also handle invalid URLs gracefully by catching exceptions from the `URL` constructor and returning `false` in such cases. No new imports are needed, as the `URL` class is available globally in modern Node.js and browsers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
