### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -47,7 +47,6 @@ export const stripMobilePrefix = (url: string) => {
     _url.hostname = 'soundcloud.com'
     return _url.toString()
   } catch (e) {
-    // If the input is not a valid URL, return as is
     return url
   }
 }

--- a/src/url.ts
+++ b/src/url.ts
@@ -41,10 +41,15 @@ export const isPersonalizedTrackURL = (url: string) => {
 }
 
 export const stripMobilePrefix = (url: string) => {
-  if (!url.includes('m.soundcloud.com')) return url
-  const _url = new URL(url)
-  _url.hostname = 'soundcloud.com'
-  return _url.toString()
+  try {
+    const _url = new URL(url)
+    if (_url.hostname !== 'm.soundcloud.com') return url
+    _url.hostname = 'soundcloud.com'
+    return _url.toString()
+  } catch (e) {
+    // If the input is not a valid URL, return as is
+    return url
+  }
 }
 
 export const isFirebaseURL = (url: string) => {


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/4](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/4)

To fix this issue, the code should parse the URL using the `URL` constructor and reliably compare the `hostname` property against the expected 'm.soundcloud.com' value, instead of searching with `includes`. This change should be made only in `stripMobilePrefix`, specifically on line 44 of `src/url.ts`. No new methods are needed, and TypeScript's built-in `URL` can be used. We should return early if the hostname is not 'm.soundcloud.com', mirroring the intent of the original code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
