### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -29,6 +29,9 @@ on:
 jobs:
   MSDO:
     # currently only windows latest is supported
+    permissions:
+      contents: read
+      security-events: write
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      id-token: write
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/26](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/26)

To fix the issue, an explicit `permissions` block should be added to the workflow or job definition. The best approach is to add `permissions` at the job level (under the `MSDO` job), immediately above the `runs-on:` key, specifying the least necessary permissions. For this workflow, uploading SARIF files to the security tab likely requires `security-events: write` permission and most other steps only require read access to repository contents. Therefore, set `contents: read` and `security-events: write`. Specifically, in the `.github/workflows/defender-for-devops.yml` file, under the `MSDO` job and above `runs-on: windows-latest`, insert:

```yaml
permissions:
  contents: read
  security-events: write
```

No additional methods or imports are needed; this is purely a configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
