### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -21,6 +21,8 @@ jobs:
 
   publish-npm:
     needs: build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/35](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/35)

To fix the problem, add an explicit `permissions` block to the `publish-npm` job in `.github/workflows/npm-publish-github-packages.yml`.  
- This block should set the permissions to the minimal required - typically `contents: read`, as is done for the `build` job, unless the job needs more.  
- Place the `permissions` block at the same indentation level as `runs-on` and `needs` for the `publish-npm` job, i.e., just above `runs-on`.  
- No external imports or additional definitions are required, as this is a change to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
