### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/TypeDoc.yml
+++ b/.github/workflows/TypeDoc.yml
@@ -1,4 +1,6 @@
 name: Generate TypeDoc
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/39](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/39)

The best fix is to add a `permissions` block to the workflow or the relevant job, specifying the minimal set of permissions required. Since the workflow must be able to push to the repository (it commits and pushes generated docs), the permission `contents: write` is required. This fix involves adding the following lines under the root of the workflow (preferably, as all steps in the job rely on this) or within the specific job definition:

```yaml
permissions:
  contents: write
```

This should be placed immediately after the `name` key to apply to the whole workflow (affecting all jobs that do not set their own `permissions`), or directly under the specific job (here `build-docs:`) to scope it to that job specifically. Either approach is accepted by GitHub; putting it at the workflow root is most explicit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
